### PR TITLE
Update Leaderboard Prefab for easier use

### DIFF
--- a/Assets/Xbox Live/Scripts/Leaderboard.cs
+++ b/Assets/Xbox Live/Scripts/Leaderboard.cs
@@ -13,12 +13,12 @@ using UnityEngine.UI;
 [Serializable]
 public class Leaderboard : MonoBehaviour
 {
+    private string socialGroup;
+
     public StatBase stat;
-    public bool isConfigured;
 
-    [Tooltip("This property needs to be set to get an unconfigured leaderboard. Example: \"all\"")]
-    public string socialGroup;
-
+    public LeaderboardTypes leaderboardType;
+    
     [Range(1, 100)]
     public uint entryCount = 10;
 
@@ -106,12 +106,7 @@ public class Leaderboard : MonoBehaviour
     {
         if (!this.isLocalUserAdded) return;
         if (this.stat == null) return;
-
-        if (this.isConfigured && string.IsNullOrEmpty(this.socialGroup))
-        {
-            throw new InvalidOperationException("If you are using a configured leaderboard you must specify a social group.");
-        }
-
+        
         LeaderboardQuery query;
         if (newPage == this.currentPage + 1 && this.leaderboardData != null && this.leaderboardData.HasNext)
         {
@@ -119,10 +114,22 @@ public class Leaderboard : MonoBehaviour
         }
         else
         {
+            if (leaderboardType == LeaderboardTypes.Global) {
+                socialGroup = null;
+            }
+
+            if (leaderboardType == LeaderboardTypes.Favorites) {
+                socialGroup = "favorite";
+            }
+
+            if (leaderboardType == LeaderboardTypes.Friends) {
+                socialGroup = "all";
+            }
+
             query = new LeaderboardQuery
             {
                 StatName = this.stat.Name,
-                SocialGroup = this.socialGroup,
+                SocialGroup = socialGroup,
                 SkipResultsToRank = newPage == 0 ? 0 : (this.currentPage * this.entryCount) - 1,
                 MaxItems = this.entryCount,
             };

--- a/Assets/Xbox Live/Scripts/Leaderboard.cs
+++ b/Assets/Xbox Live/Scripts/Leaderboard.cs
@@ -114,16 +114,16 @@ public class Leaderboard : MonoBehaviour
         }
         else
         {
-            if (leaderboardType == LeaderboardTypes.Global) {
-                socialGroup = null;
-            }
-
-            if (leaderboardType == LeaderboardTypes.Favorites) {
-                socialGroup = "favorite";
-            }
-
-            if (leaderboardType == LeaderboardTypes.Friends) {
-                socialGroup = "all";
+            switch (leaderboardType) {
+                case LeaderboardTypes.Global:
+                    socialGroup = null;
+                    break;
+                case LeaderboardTypes.Favorites:
+                    socialGroup = "favorite";
+                    break;
+                case LeaderboardTypes.Friends:
+                    socialGroup = "all";
+                    break;
             }
 
             query = new LeaderboardQuery

--- a/Assets/Xbox Live/Scripts/LeaderboardTypes.cs
+++ b/Assets/Xbox Live/Scripts/LeaderboardTypes.cs
@@ -1,4 +1,6 @@
-﻿public enum LeaderboardTypes{
+﻿// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+public enum LeaderboardTypes{
     Global,
     Friends,
     Favorites

--- a/Assets/Xbox Live/Scripts/LeaderboardTypes.cs
+++ b/Assets/Xbox Live/Scripts/LeaderboardTypes.cs
@@ -1,0 +1,5 @@
+﻿public enum LeaderboardTypes{
+    Global,
+    Friends,
+    Favorites
+}

--- a/Assets/Xbox Live/Scripts/LeaderboardTypes.cs.meta
+++ b/Assets/Xbox Live/Scripts/LeaderboardTypes.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a4f98ed0fb9f2e94f96a4690b8ec61ff
+timeCreated: 1496953855
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Instead of typing a leaderboard social group, you can now just select the leaderboard type from a drop down list.