### PR TITLE
Cleaning up existing code. 

### DIFF
--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/System/XboxLiveCallbackContext.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/System/XboxLiveCallbackContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Xbox.Services.System
     {
         public T Context;
 
-        public TaskCompletionSource<T2> TaskCompletionSource;      
+        public TaskCompletionSource<T2> TaskCompletionSource;
 
         public List<IntPtr> PointersToRelease;
         public List<IntPtr> PointersToFree;

--- a/CSharpSource/Source/api/Common/XboxException.cs
+++ b/CSharpSource/Source/api/Common/XboxException.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Xbox.Services
 {
     using global::System;
+    using Microsoft.Xbox.Services.System;
 
     public class XboxException : Exception
     {
@@ -21,6 +22,11 @@ namespace Microsoft.Xbox.Services
         }
 
         public XboxException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        internal XboxException(XSAPI_RESULT result)
+            : base(string.Format("Xbox Services flat C API returned error {0}", result.ToString("g")))
         {
         }
     }

--- a/CSharpSource/Source/api/Common/XboxLive.cs
+++ b/CSharpSource/Source/api/Common/XboxLive.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Xbox.Services
     {
         private bool disposed;
         private static XboxLive instance;
-        private static IntPtr xsapiNativeDll;
+        private static IntPtr xsapiNativeDll = IntPtr.Zero;
         private XboxLiveSettings settings;
         private IStatsManager statsManager;
         private ISocialManager socialManager;
@@ -25,7 +25,9 @@ namespace Microsoft.Xbox.Services
         private static readonly object instanceLock = new object();
         private readonly XboxLiveAppConfiguration appConfig;
 
-        private delegate XsapiResult XBLGlobalInitialize();
+        internal const string FlatCDllName = "Microsoft.Xbox.Services.140.UWP.C.dll";
+
+        private delegate XSAPI_RESULT XBLGlobalInitialize();
         private delegate void XBLGlobalCleanup();
 
         private XboxLive()
@@ -48,7 +50,7 @@ namespace Microsoft.Xbox.Services
                 string path = Directory.GetCurrentDirectory() + fileName;
                 xsapiNativeDll = LoadNativeDll(path);
 
-                var intializationResult = this.Invoke<XsapiResult, XBLGlobalInitialize>();
+                var intializationResult = this.Invoke<XSAPI_RESULT, XBLGlobalInitialize>();
                 // TODO handle this better
             }
             catch (Exception)

--- a/CSharpSource/Source/api/System/XboxLiveResult.cs
+++ b/CSharpSource/Source/api/System/XboxLiveResult.cs
@@ -6,25 +6,43 @@ namespace Microsoft.Xbox.Services.System
     using global::System;
     using global::System.Runtime.InteropServices;
 
-    internal enum XsapiResult
+    internal enum XSAPI_RESULT : int
     {
-        XSAPI_OK = 0,
-        XSAPI_E_FAIL = -1,
-        XSAPI_E_POINTER = -2,
-        XSAPI_E_INVALIDARG = -3,
-        XSAPI_E_OUTOFMEMORY = -4,
-        XSAPI_E_BUFFERTOOSMALL = -5,
-        XSAPI_E_NOTINITIALIZED = -6,
-        XSAPI_E_FEATURENOTPRESENT = -7
+        XSAPI_RESULT_OK = 0,
+
+        //////////////////////////////////////////////////////////////////////////
+        // LibHttpClient errors
+        //////////////////////////////////////////////////////////////////////////
+        XSAPI_RESULT_E_HC_FAIL = -1,
+        XSAPI_RESULT_E_HC_POINTER = -2,
+        XSAPI_RESULT_E_HC_INVALIDARG = -3,
+        XSAPI_RESULT_E_HC_OUTOFMEMORY = -4,
+        XSAPI_RESULT_E_HC_BUFFERTOOSMALL = -5,
+        XSAPI_RESULT_E_HC_NOTINITIALIZED = -6,
+        XSAPI_RESULT_E_HC_FEATURENOTPRESENT = -7,
+
+        XSAPI_RESULT_E_HC_MIN = XSAPI_RESULT_E_HC_FEATURENOTPRESENT,
+        XSAPI_RESULT_E_HC_MAX = XSAPI_RESULT_E_HC_FAIL,
+
+        //////////////////////////////////////////////////////////////////////////
+        // XSAPI Core error conditions
+        //////////////////////////////////////////////////////////////////////////
+        XSAPI_RESULT_E_GENERIC_ERROR = 1,
+        XSAPI_RESULT_E_OUT_OF_RANGE = 2,
+        XSAPI_RESULT_E_AUTH = 3,
+        XSAPI_RESULT_E_NETWORK = 4,
+        XSAPI_RESULT_E_HTTP = 5,
+        XSAPI_RESULT_E_HTTP_404_NOT_FOUND = 6,
+        XSAPI_RESULT_E_HTTP_412_PRECONDITION_FAILED = 7,
+        XSAPI_RESULT_E_HTTP_429_TOO_MANY_REQUESTS = 8,
+        XSAPI_RESULT_E_HTTP_SERVICE_TIMEOUT = 9,
+        XSAPI_RESULT_E_RTA = 10
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct XboxLiveResult
+    internal struct XSAPI_RESULT_INFO
     {
-        [MarshalAsAttribute(UnmanagedType.I4)]
-        public int errorCode;
-
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        public String errorMessage;
+        public XSAPI_RESULT errorCode;
+        public IntPtr errorMessage;
     }
 }

--- a/CppSource/Build/Microsoft.Xbox.Services.140.UWP.C/Microsoft.Xbox.Services.140.UWP.C.vcxproj
+++ b/CppSource/Build/Microsoft.Xbox.Services.140.UWP.C/Microsoft.Xbox.Services.140.UWP.C.vcxproj
@@ -151,6 +151,7 @@
     <ClCompile Include="..\..\Source\Shared\utils.cpp" />
     <ClCompile Include="..\..\Source\Shared\xbox_live_app_config.cpp" />
     <ClCompile Include="..\..\Source\System\user.cpp" />
+    <ClCompile Include="..\..\Source\System\user_impl_c.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Include\xsapi\errors_c.h" />

--- a/CppSource/Build/Microsoft.Xbox.Services.140.UWP.C/Microsoft.Xbox.Services.140.UWP.C.vcxproj.filters
+++ b/CppSource/Build/Microsoft.Xbox.Services.140.UWP.C/Microsoft.Xbox.Services.140.UWP.C.vcxproj.filters
@@ -101,6 +101,9 @@
     <ClCompile Include="..\..\Source\Shared\singleton.cpp">
       <Filter>C++ Source\Shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Source\System\user_impl_c.cpp">
+      <Filter>C++ Source\System</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/CppSource/Include/xsapi/errors_c.h
+++ b/CppSource/Include/xsapi/errors_c.h
@@ -8,11 +8,45 @@
 extern "C" {
 #endif
 
-typedef struct XboxLiveResult
+typedef enum XSAPI_RESULT
 {
-    int errorCode;
+    XSAPI_RESULT_OK = 0,
+
+    //////////////////////////////////////////////////////////////////////////
+    // LibHttpClient errors
+    //////////////////////////////////////////////////////////////////////////
+    XSAPI_RESULT_E_HC_FAIL = -1,
+    XSAPI_RESULT_E_HC_POINTER = -2,
+    XSAPI_RESULT_E_HC_INVALIDARG = -3,
+    XSAPI_RESULT_E_HC_OUTOFMEMORY = -4,
+    XSAPI_RESULT_E_HC_BUFFERTOOSMALL = -5,
+    XSAPI_RESULT_E_HC_NOTINITIALIZED = -6,
+    XSAPI_RESULT_E_HC_FEATURENOTPRESENT = -7,
+
+    XSAPI_RESULT_E_HC_MIN = XSAPI_RESULT_E_HC_FEATURENOTPRESENT,
+    XSAPI_RESULT_E_HC_MAX = XSAPI_RESULT_E_HC_FAIL,
+
+    //////////////////////////////////////////////////////////////////////////
+    // XSAPI Core error conditions
+    //////////////////////////////////////////////////////////////////////////
+    XSAPI_RESULT_E_GENERIC_ERROR = 1,
+    XSAPI_RESULT_E_OUT_OF_RANGE = 2,
+    XSAPI_RESULT_E_AUTH = 3,
+    XSAPI_RESULT_E_NETWORK = 4,
+    XSAPI_RESULT_E_HTTP = 5,
+    XSAPI_RESULT_E_HTTP_404_NOT_FOUND = 6,
+    XSAPI_RESULT_E_HTTP_412_PRECONDITION_FAILED = 7,
+    XSAPI_RESULT_E_HTTP_429_TOO_MANY_REQUESTS = 8,
+    XSAPI_RESULT_E_HTTP_SERVICE_TIMEOUT = 9,
+    XSAPI_RESULT_E_RTA = 10
+
+} XSAPI_RESULT;
+
+typedef struct XSAPI_RESULT_INFO
+{
+    XSAPI_RESULT errorCode;
     PCSTR errorMessage;
-} XboxLiveResult;
+} XSAPI_RESULT_INFO;
 
 #if defined(__cplusplus)
 } // end extern "C"

--- a/CppSource/Include/xsapi/system_c.h
+++ b/CppSource/Include/xsapi/system_c.h
@@ -11,56 +11,54 @@ extern "C" {
 
 #if !XDK_API
 
-struct XboxLiveUserImpl;
+struct XSAPI_XBOX_LIVE_USER_IMPL;
 
-typedef enum SIGN_IN_STATUS
+typedef enum XSAPI_SIGN_IN_STATUS
 {
     /// <summary>
     /// Signed in successfully.
     /// </summary>
-    SUCCESS = 0,
+    XSAPI_SIGN_IN_STATUS_SUCCESS = 0,
 
     /// <summary>
     /// Need to invoke the signin API (w/ UX) to let the user take necessary actions for the sign-in operation to continue.
     /// Can only be returned from signin_silently().
     /// </summary>
-    USER_INTERACTION_REQUIRED,
+    XSAPI_SIGN_IN_STATUS_USER_INTERACTION_REQUIRED,
 
     /// <summary>
     /// The user decided to cancel the sign-in operation.
     /// Can only be returned from signin().
     /// </summary>
-    USER_CANCEL
-} SIGN_IN_STATUS;
+    XSAPI_SIGN_IN_STATUS_USER_CANCEL
+} XSAPI_SIGN_IN_STATUS;
 
-typedef struct XboxLiveUser
+typedef struct XSAPI_XBOX_LIVE_USER
 {
     PCSTR xboxUserId; 
     PCSTR gamertag;
     PCSTR ageGroup;
     PCSTR privileges;
     bool isSignedIn;
-
 #if UWP_API
     PCSTR webAccountId;
     Windows::System::User^ windowsSystemUser;
 #endif
-    
-    XboxLiveUserImpl *pImpl;
-} XboxLiveUser;
+    XSAPI_XBOX_LIVE_USER_IMPL *pImpl;
+} XSAPI_XBOX_LIVE_USER;
 
-typedef struct SignInResultPayload
+typedef struct XSAPI_SIGN_IN_RESULT_PAYLOAD
 {
-    SIGN_IN_STATUS status;
-} SignInResultPayload;
+    XSAPI_SIGN_IN_STATUS status;
+} XSAPI_SIGN_IN_RESULT_PAYLOAD;
 
-typedef struct SignInResult
+typedef struct XSAPI_SIGN_IN_RESULT
 {
-    XboxLiveResult result;
-    SignInResultPayload payload;
-} SignInResult;
+    XSAPI_RESULT_INFO result;
+    XSAPI_SIGN_IN_RESULT_PAYLOAD payload;
+} XSAPI_SIGN_IN_RESULT;
 
-typedef struct TokenAndSignatureResultPayload
+typedef struct XSAPI_TOKEN_AND_SIGNATURE_RESULT_PAYLOAD
 {
     PCSTR token;
     PCSTR signature;
@@ -70,17 +68,17 @@ typedef struct TokenAndSignatureResultPayload
     PCSTR ageGroup;
     PCSTR privileges;
     PCSTR webAccountId;
-} TokenAndSignatureResultPayload;
+} XSAPI_TOKEN_AND_SIGNATURE_RESULT_PAYLOAD;
 
-typedef struct TokenAndSignatureResult
+typedef struct XSAPI_TOKEN_AND_SIGNATURE_RESULT
 {
-    XboxLiveResult result;
-    TokenAndSignatureResultPayload payload;
-} TokenAndSignatureResult;
+    XSAPI_RESULT_INFO result;
+    XSAPI_TOKEN_AND_SIGNATURE_RESULT_PAYLOAD payload;
+} XSAPI_TOKEN_AND_SIGNATURE_RESULT;
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserCreate(
-    _Out_ XboxLiveUser** ppUser
+    _Out_ XSAPI_XBOX_LIVE_USER** ppUser
     ) XSAPI_NOEXCEPT;
 
 #if UWP_API
@@ -88,33 +86,33 @@ XboxLiveUserCreate(
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserCreateFromSystemUser(
     _In_ Windows::System::User^ creationContext,
-    _Out_ XboxLiveUser** ppUser
+    _Out_ XSAPI_XBOX_LIVE_USER** ppUser
     ) XSAPI_NOEXCEPT;
 
 #endif
 
 XSAPI_DLLEXPORT void XBL_CALLING_CONV
 XboxLiveUserDelete(
-    _In_ XboxLiveUser* user
+    _In_ XSAPI_XBOX_LIVE_USER* pUser
     ) XSAPI_NOEXCEPT;
 
-typedef void(*SignInCompletionRoutine)(
-    _In_ SignInResult result,
+typedef void(*XSAPI_SIGN_IN_COMPLETION_ROUTINE)(
+    _In_ XSAPI_SIGN_IN_RESULT result,
     _In_opt_ void* context
     );
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserSignIn(
-    _Inout_ XboxLiveUser* user,
-    _In_ SignInCompletionRoutine completionRoutine,
+    _Inout_ XSAPI_XBOX_LIVE_USER* pUser,
+    _In_ XSAPI_SIGN_IN_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserSignInSilently(
-    _Inout_ XboxLiveUser* user,
-    _In_ SignInCompletionRoutine completionRoutine,
+    _Inout_ XSAPI_XBOX_LIVE_USER* pUser,
+    _In_ XSAPI_SIGN_IN_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
@@ -123,53 +121,53 @@ XboxLiveUserSignInSilently(
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserSignInWithCoreDispatcher(
-    _Inout_ XboxLiveUser* user,
+    _Inout_ XSAPI_XBOX_LIVE_USER* pUser,
     _In_ Platform::Object^ coreDispatcher,
-    _In_ SignInCompletionRoutine completionRoutine,
+    _In_ XSAPI_SIGN_IN_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserSignInSilentlyWithCoreDispatcher(
-    _Inout_ XboxLiveUser* user,
+    _Inout_ XSAPI_XBOX_LIVE_USER* pUser,
     _In_ Platform::Object^ coreDispatcher,
-    _In_ SignInCompletionRoutine completionRoutine,
+    _In_ XSAPI_SIGN_IN_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
 
 #endif
 
-typedef void(*GetTokenAndSignatureCompletionRoutine)(
-    _In_ TokenAndSignatureResult result,
+typedef void(*XSAPI_GET_TOKEN_AND_SIGNATURE_COMPLETION_ROUTINE)(
+    _In_ XSAPI_TOKEN_AND_SIGNATURE_RESULT result,
     _In_opt_ void* context
     );
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 XboxLiveUserGetTokenAndSignature(
-    _Inout_ XboxLiveUser* user,
+    _In_ XSAPI_XBOX_LIVE_USER* pUser,
     _In_ PCSTR httpMethod,
     _In_ PCSTR url,
     _In_ PCSTR headers,
     _In_ PCSTR requestBodyString,
-    _In_ GetTokenAndSignatureCompletionRoutine completionRoutine,
+    _In_ XSAPI_GET_TOKEN_AND_SIGNATURE_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
 
-typedef void(*SignOutCompletedHandler)(
-    _In_ XboxLiveUser* user
+typedef void(*XSAPI_SIGN_OUT_COMPLETED_HANDLER)(
+    _In_ XSAPI_XBOX_LIVE_USER* pUser
     );
 
-XSAPI_DLLEXPORT function_context XBL_CALLING_CONV
+XSAPI_DLLEXPORT FUNCTION_CONTEXT XBL_CALLING_CONV
 AddSignOutCompletedHandler(
-    _In_ SignOutCompletedHandler signOutHandler
+    _In_ XSAPI_SIGN_OUT_COMPLETED_HANDLER signOutHandler
     ) XSAPI_NOEXCEPT;
 
 XSAPI_DLLEXPORT void XBL_CALLING_CONV
 RemoveSignOutCompletedHandler(
-    _In_ function_context context
+    _In_ FUNCTION_CONTEXT context
     ) XSAPI_NOEXCEPT;
 
 #endif //!XDK_API

--- a/CppSource/Include/xsapi/title_callable_ui_c.h
+++ b/CppSource/Include/xsapi/title_callable_ui_c.h
@@ -10,112 +10,112 @@ extern "C" {
 #endif
 
 /// <summary>List of gaming privilege that a user can have.</summary>
-typedef enum GAMING_PRIVILEGE
+typedef enum XSAPI_GAMING_PRIVILEGE
 {
     /// <summary>The user can broadcast live gameplay.</summary>
-    GAMING_PRIVILEGE_BROADCAST = 190,
+    XSAPI_GAMING_PRIVILEGE_BROADCAST = 190,
 
     /// <summary>The user can view other user's friends list if this privilege is present.</summary>
-    GAMING_PRIVILEGE_VIEW_FRIENDS_LIST = 197,
+    XSAPI_GAMING_PRIVILEGE_VIEW_FRIENDS_LIST = 197,
 
     /// <summary>The user can upload recorded in-game videos to the cloud if this privilege is present. Viewing GameDVRs is subject to privacy controls.</summary>
-    GAMING_PRIVILEGE_GAME_DVR = 198,
+    XSAPI_GAMING_PRIVILEGE_GAME_DVR = 198,
 
     /// <summary>Kinect recorded content can be uploaded to the cloud for the user and made accessible to anyone if this privilege is present. Viewing other user's Kinect content is subject to a privacy setting.</summary>
-    GAMING_PRIVILEGE_SHARE_KINECT_CONTENT = 199,
+    XSAPI_GAMING_PRIVILEGE_SHARE_KINECT_CONTENT = 199,
 
     /// <summary>The user can join a party session if this privilege is present</summary>
-    GAMING_PRIVILEGE_MULTIPLAYER_PARTIES = 203,
+    XSAPI_GAMING_PRIVILEGE_MULTIPLAYER_PARTIES = 203,
 
     /// <summary>The user can participate in voice chat during parties and multiplayer game sessions if this privilege is present. Communicating with other users is subject to additional privacy permission checks</summary>
-    GAMING_PRIVILEGE_COMMUNICATION_VOICE_INGAME = 205,
+    XSAPI_GAMING_PRIVILEGE_COMMUNICATION_VOICE_INGAME = 205,
 
     /// <summary>The user can use voice communication with Skype on Xbox One if this privilege is present</summary>
-    GAMING_PRIVILEGE_COMMUNICATION_VOICE_SKYPE = 206,
+    XSAPI_GAMING_PRIVILEGE_COMMUNICATION_VOICE_SKYPE = 206,
 
     /// <summary>The user can allocate a cloud compute cluster and manage a cloud compute cluster for a hosted game session if this privilege is present</summary>
-    GAMING_PRIVILEGE_CLOUD_GAMING_MANAGE_SESSION = 207,
+    XSAPI_GAMING_PRIVILEGE_CLOUD_GAMING_MANAGE_SESSION = 207,
 
     /// <summary>The user can join a cloud compute session if this privilege is present</summary>
-    GAMING_PRIVILEGE_CLOUD_GAMING_JOIN_SESSION = 208,
+    XSAPI_GAMING_PRIVILEGE_CLOUD_GAMING_JOIN_SESSION = 208,
 
     /// <summary>The user can save games in cloud title storage if this privilege is present</summary>
-    GAMING_PRIVILEGE_CLOUD_SAVED_GAMES = 209,
+    XSAPI_GAMING_PRIVILEGE_CLOUD_SAVED_GAMES = 209,
 
     /// <summary>The user can share content with others if this privilege is present</summary>
-    GAMING_PRIVILEGE_SHARE_CONTENT = 211,
+    XSAPI_GAMING_PRIVILEGE_SHARE_CONTENT = 211,
 
     /// <summary>The user can purchase, download and launch premium content available with the Xbox LIVE Gold subscription if this privilege is present</summary>
-    GAMING_PRIVILEGE_PREMIUM_CONTENT = 214,
+    XSAPI_GAMING_PRIVILEGE_PREMIUM_CONTENT = 214,
 
     /// <summary>The user can purchase and download premium subscription content and use premium subscription features when this privilege is present</summary>
-    GAMING_PRIVILEGE_SUBSCRIPTION_CONTENT = 219,
+    XSAPI_GAMING_PRIVILEGE_SUBSCRIPTION_CONTENT = 219,
 
     /// <summary>The user is allowed to share progress information on social networks when this privilege is present</summary>
-    GAMING_PRIVILEGE_SOCIAL_NETWORK_SHARING = 220,
+    XSAPI_GAMING_PRIVILEGE_SOCIAL_NETWORK_SHARING = 220,
 
     /// <summary>The user can access premium video services if this privilege is present</summary>
-    GAMING_PRIVILEGE_PREMIUM_VIDEO = 224,
+    XSAPI_GAMING_PRIVILEGE_PREMIUM_VIDEO = 224,
 
     /// <summary>The user can use video communication with Skype or other providers when this privilege is present. Communicating with other users is subject to additional privacy permission checks</summary>
-    GAMING_PRIVILEGE_VIDEO_COMMUNICATIONS = 235,
+    XSAPI_GAMING_PRIVILEGE_VIDEO_COMMUNICATIONS = 235,
 
     /// <summary>The user is authorized to purchase content when this privilege is present</summary>
-    GAMING_PRIVILEGE_PURCHASE_CONTENT = 245,
+    XSAPI_GAMING_PRIVILEGE_PURCHASE_CONTENT = 245,
 
     /// <summary>The user is authorized to download and view online user created content when this privilege is present.</summary>
-    GAMING_PRIVILEGE_USER_CREATED_CONTENT = 247,
+    XSAPI_GAMING_PRIVILEGE_USER_CREATED_CONTENT = 247,
 
     /// <summary>The user is authorized to view other user's profiles when this privilege is present. Viewing other user's profiles is subject to additional privacy checks</summary>
-    GAMING_PRIVILEGE_PROFILE_VIEWING = 249,
+    XSAPI_GAMING_PRIVILEGE_PROFILE_VIEWING = 249,
 
     /// <summary>The user can use asynchronous text messaging with anyone when this privilege is present. Extra privacy permissions checks are required to determine who the user is authorized to communicate with. Communicating with other users is subject to additional privacy permission checks</summary>
-    GAMING_PRIVILEGE_COMMUNICATIONS = 252,
+    XSAPI_GAMING_PRIVILEGE_COMMUNICATIONS = 252,
 
     /// <summary>The user can join a multiplayer sessions for a game when this privilege is present.</summary>
-    GAMING_PRIVILEGE_MULTIPLAYER_SESSIONS = 254,
+    XSAPI_GAMING_PRIVILEGE_MULTIPLAYER_SESSIONS = 254,
 
     /// <summary>The user can follow other Xbox LIVE users and add Xbox LIVE friends when this privilege is present.</summary>
-    GAMING_PRIVILEGE_ADD_FRIEND = 255
-} GAMING_PRIVILEGE;
+    XSAPI_GAMING_PRIVILEGE_ADD_FRIEND = 255
+} XSAPI_GAMING_PRIVILEGE;
 
-typedef struct TCUICheckGamingPrivilegeResult
+typedef struct XSAPI_TCUI_CHECK_GAMING_PRIVILEGE_RESULT
 {
     bool hasPrivilege;
-    XboxLiveResult result;
-} TCUICheckGamingPrivilegeResult;
+    XSAPI_RESULT_INFO result;
+} XSAPI_TCUI_CHECK_GAMING_PRIVILEGE_RESULT;
 
-typedef void(*TCUIShowProfileCardUICompletionRoutine)(
-    _In_ XboxLiveResult result,
+typedef void(*XSAPI_SHOW_PROFILE_CARD_UI_COMPLETION_ROUTINE)(
+    _In_ XSAPI_RESULT_INFO result,
     _In_opt_ void* completionRoutineContext
     );
 
-typedef void(*TCUICheckGamingPrivilegeCompletionRoutine)(
-    _In_ TCUICheckGamingPrivilegeResult result,
+typedef void(*XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE)(
+    _In_ XSAPI_TCUI_CHECK_GAMING_PRIVILEGE_RESULT result,
     _In_opt_ void* completionRoutineContext
     );
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 TCUIShowProfileCardUI(
     _In_ PCSTR targetXboxUserId,
-    _In_ TCUIShowProfileCardUICompletionRoutine completionRoutine,
+    _In_ XSAPI_SHOW_PROFILE_CARD_UI_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 TCUICheckGamingPrivilegeSilently(
-    _In_ GAMING_PRIVILEGE privilege,
-    _In_ TCUICheckGamingPrivilegeCompletionRoutine completionRoutine,
+    _In_ XSAPI_GAMING_PRIVILEGE privilege,
+    _In_ XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 TCUICheckGamingPrivilegeWithUI(
-    _In_ GAMING_PRIVILEGE privilege,
+    _In_ XSAPI_GAMING_PRIVILEGE privilege,
     _In_ PCSTR friendlyMessage,
-    _In_ TCUICheckGamingPrivilegeCompletionRoutine completionRoutine,
+    _In_ XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT;

--- a/CppSource/Include/xsapi/types_c.h
+++ b/CppSource/Include/xsapi/types_c.h
@@ -80,28 +80,8 @@
 
 #define XBL_CALLING_CONV __cdecl
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
-typedef enum XSAPI_RESULT
-{
-    XSAPI_OK = 0,
-    XSAPI_E_FAIL = -1,
-    XSAPI_E_POINTER = -2,
-    XSAPI_E_INVALIDARG = -3,
-    XSAPI_E_OUTOFMEMORY = -4,
-    XSAPI_E_BUFFERTOOSMALL = -5,
-    XSAPI_E_NOTINITIALIZED = -6,
-    XSAPI_E_FEATURENOTPRESENT = -7
-} XSAPI_RESULT;
-
 #ifdef __cplusplus
 #define XSAPI_NOEXCEPT noexcept
 #else
 #define XSAPI_NOEXCEPT
 #endif
-
-#if defined(__cplusplus)
-} // end extern "C"
-#endif // defined(__cplusplus)

--- a/CppSource/Include/xsapi/xbox_live_app_config_c.h
+++ b/CppSource/Include/xsapi/xbox_live_app_config_c.h
@@ -9,17 +9,17 @@
 extern "C" {
 #endif
 
-typedef struct XboxLiveAppConfig
+typedef struct XSAPI_XBOX_LIVE_APP_CONFIG
 {
     uint32_t titleId;
     PCSTR scid;
     PCSTR environment;
     PCSTR sandbox;
-} XboxLiveAppConfig;
+} XSAPI_XBOX_LIVE_APP_CONFIG;
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 GetXboxLiveAppConfigSingleton(
-    _Out_ XboxLiveAppConfig const** ppConfig
+    _Out_ CONST XSAPI_XBOX_LIVE_APP_CONFIG** ppConfig
     );
 
 #if defined(__cplusplus)

--- a/CppSource/Include/xsapi/xbox_live_context_c.h
+++ b/CppSource/Include/xsapi/xbox_live_context_c.h
@@ -8,40 +8,34 @@
 extern "C" {
 #endif
 
-struct XboxLiveUser;
-struct XboxLiveAppConfig;
-struct XboxLiveContextImpl;
+struct XSAPI_XBOX_LIVE_USER;
+struct XSAPI_XBOX_LIVE_APP_CONFIG;
+struct XSAPI_XBOX_LIVE_CONTEXT_IMPL;
 
-typedef struct XboxLiveContext
+typedef struct XSAPI_XBOX_LIVE_CONTEXT
 {
     PCSTR xboxUserId;
-
 #if XDK_API | XBOX_UWP
     Windows::Xbox::System::User^ user;
 #else
-    XboxLiveUser *user;
+    XSAPI_XBOX_LIVE_USER* pUser;
 #endif
-
-    XboxLiveAppConfig const *appConfig;
-
-    // TODO add services
-
-    XboxLiveContextImpl *pImpl;
-
-} XboxLiveContext;
+    CONST XSAPI_XBOX_LIVE_APP_CONFIG* pAppConfig;
+    XSAPI_XBOX_LIVE_CONTEXT_IMPL* pImpl;
+} XSAPI_XBOX_LIVE_CONTEXT;
 
 #if !(XDK_API | XBOX_UWP)
 
-XSAPI_DLLEXPORT XboxLiveContext* XBL_CALLING_CONV
+XSAPI_DLLEXPORT XSAPI_XBOX_LIVE_CONTEXT* XBL_CALLING_CONV
 XboxLiveContextCreate(
-    XboxLiveUser *user
+    XSAPI_XBOX_LIVE_USER* pUser
     );
 
 #endif
 
 XSAPI_DLLEXPORT void XBL_CALLING_CONV
 XboxLiveContextDelete(
-    XboxLiveContext *context
+    XSAPI_XBOX_LIVE_CONTEXT* pContext
     );
 
 #if defined(__cplusplus)

--- a/CppSource/Source/Services/Common/pch_common.h
+++ b/CppSource/Source/Services/Common/pch_common.h
@@ -63,7 +63,7 @@ typedef std::chrono::system_clock chrono_clock_t;
 typedef std::chrono::steady_clock chrono_clock_t;
 #endif
 
-typedef int32_t function_context;
+typedef int32_t FUNCTION_CONTEXT;
 
 // libHttpClient
 #include "httpClient/httpClient.h"
@@ -71,6 +71,7 @@ typedef int32_t function_context;
 #include "httpClient/trace.h"
 
 #include "xsapi/types_c.h"
+#include "xsapi/errors_c.h"
 #include "xsapi/services_c.h"
 #include "utils.h"
 #include "singleton.h"

--- a/CppSource/Source/Services/Common/services_global.cpp
+++ b/CppSource/Source/Services/Common/services_global.cpp
@@ -15,7 +15,7 @@ try
     }
     singleton->m_threadPool->start_threads();
     
-    return XSAPI_OK;
+    return XSAPI_RESULT_OK;
 }
 CATCH_RETURN()
 

--- a/CppSource/Source/Services/Common/taskargs.cpp
+++ b/CppSource/Source/Services/Common/taskargs.cpp
@@ -4,24 +4,24 @@
 #include "taskargs.h"
 
 xbl_args_xbox_live_user_sign_in::xbl_args_xbox_live_user_sign_in(
-    _In_ XboxLiveUser* _user,
+    _In_ XSAPI_XBOX_LIVE_USER* _pUser,
     _In_ Platform::Object^ _coreDispatcher,
     _In_opt_ bool _signInSilently
     )
-    : user(_user),
+    : pUser(_pUser),
     coreDispatcher(_coreDispatcher),
     signInSilently(_signInSilently)
 {
 }
 
 xbl_args_xbox_live_user_get_token_and_signature::xbl_args_xbox_live_user_get_token_and_signature(
-    _In_ XboxLiveUser* _user,
+    _In_ XSAPI_XBOX_LIVE_USER* _pUser,
     _In_ PCSTR _httpMethod,
     _In_ PCSTR _url,
     _In_ PCSTR _headers,
     _In_ PCSTR _requestBodyString
     )
-    : user(_user),
+    : pUser(_pUser),
     httpMethod(_httpMethod),
     url(_url),
     headers(_headers),

--- a/CppSource/Source/Services/Common/taskargs.h
+++ b/CppSource/Source/Services/Common/taskargs.h
@@ -13,45 +13,45 @@ struct xbl_args
     virtual ~xbl_args() {}
 };
 
-struct xbl_args_tcui_show_profile_card_ui : public xbl_args<XboxLiveResult>
+struct xbl_args_tcui_show_profile_card_ui : public xbl_args<XSAPI_RESULT_INFO>
 {
     PCSTR targetXboxUserId;
     std::string resultErrorMsg;
 };
 
-struct xbl_args_tcui_check_gaming_privilege : public xbl_args<TCUICheckGamingPrivilegeResult>
+struct xbl_args_tcui_check_gaming_privilege : public xbl_args<XSAPI_TCUI_CHECK_GAMING_PRIVILEGE_RESULT>
 {
-    GAMING_PRIVILEGE privilege;
+    XSAPI_GAMING_PRIVILEGE privilege;
     std::string resultErrorMsg;
     std::string friendlyMessage;
 };
 
-struct xbl_args_xbox_live_user_sign_in : public xbl_args<SignInResult>
+struct xbl_args_xbox_live_user_sign_in : public xbl_args<XSAPI_SIGN_IN_RESULT>
 {
     xbl_args_xbox_live_user_sign_in(
-        _In_ XboxLiveUser* user,
+        _In_ XSAPI_XBOX_LIVE_USER* pUser,
         _In_ Platform::Object^ coreDispatcher,
         _In_opt_ bool signInSilently = false
         );
 
-    XboxLiveUser* user;
+    XSAPI_XBOX_LIVE_USER* pUser;
     bool signInSilently;
     Platform::Object^ coreDispatcher;
 
     std::string resultErrorMsg;
 };
 
-struct xbl_args_xbox_live_user_get_token_and_signature : public xbl_args<TokenAndSignatureResult>
+struct xbl_args_xbox_live_user_get_token_and_signature : public xbl_args<XSAPI_TOKEN_AND_SIGNATURE_RESULT>
 {
     xbl_args_xbox_live_user_get_token_and_signature(
-        _In_ XboxLiveUser* user,
+        _In_ XSAPI_XBOX_LIVE_USER* pUser,
         _In_ PCSTR httpMethod,
         _In_ PCSTR url,
         _In_ PCSTR headers,
         _In_ PCSTR requestBodyString
         );
 
-    XboxLiveUser* user;
+    XSAPI_XBOX_LIVE_USER* pUser;
     PCSTR httpMethod;
     PCSTR url;
     PCSTR headers;
@@ -69,7 +69,7 @@ struct xbl_args_xbox_live_user_get_token_and_signature : public xbl_args<TokenAn
     std::string resultErrorMsg;
 };
 
-struct xbl_args_xbox_live_user_refresh_token : public xbl_args<XboxLiveResult>
+struct xbl_args_xbox_live_user_refresh_token : public xbl_args<XSAPI_RESULT_INFO>
 {
     std::string resultErrorMsg;
 };

--- a/CppSource/Source/Services/Common/xbox_live_app_config_impl.h
+++ b/CppSource/Source/Services/Common/xbox_live_app_config_impl.h
@@ -9,10 +9,12 @@ namespace xbox {
     }
 }
 
-struct XboxLiveAppConfigImpl
+struct XBOX_LIVE_APP_CONFIG_IMPL
 {
-    XboxLiveAppConfigImpl();
+public:
+    XBOX_LIVE_APP_CONFIG_IMPL();
 
+private:
     std::string m_scid;
     std::string m_environment;
     std::string m_sandbox;

--- a/CppSource/Source/Services/Common/xbox_live_context.cpp
+++ b/CppSource/Source/Services/Common/xbox_live_context.cpp
@@ -8,43 +8,45 @@
 
 using namespace xbox::services;
 
-struct XboxLiveContextImpl
+struct XSAPI_XBOX_LIVE_CONTEXT_IMPL
 {
-    XboxLiveContextImpl(
-        _In_ XboxLiveUser *user,
-        _In_ XboxLiveContext *cContext
+public:
+    XSAPI_XBOX_LIVE_CONTEXT_IMPL(
+        _In_ XSAPI_XBOX_LIVE_USER* pUser,
+        _In_ XSAPI_XBOX_LIVE_CONTEXT* pXboxLiveContext
         ) 
-        : m_cContext(cContext),
-        m_cppContext(user->pImpl->m_cppUser)
+        : m_pXboxLiveContext(pXboxLiveContext),
+        m_cppContext(pUser->pImpl->cppUser())
     {
-         GetXboxLiveAppConfigSingleton(&(cContext->appConfig));
+        GetXboxLiveAppConfigSingleton(&m_pXboxLiveContext->pAppConfig);
     }
 
-    XboxLiveContext *m_cContext;
+private:
+    XSAPI_XBOX_LIVE_CONTEXT* m_pXboxLiveContext;
     xbox_live_context m_cppContext;
 };
 
-XSAPI_DLLEXPORT XboxLiveContext* XBL_CALLING_CONV
+XSAPI_DLLEXPORT XSAPI_XBOX_LIVE_CONTEXT* XBL_CALLING_CONV
 XboxLiveContextCreate(
-    XboxLiveUser *user
+    XSAPI_XBOX_LIVE_USER* pUser
     )
 {
     // TODO improve error handling
-    if (user == nullptr)
+    if (pUser == nullptr)
     {
         return nullptr;
     }
 
     verify_global_init();
 
-    auto context = new XboxLiveContext();
-    context->pImpl = new XboxLiveContextImpl(user, context);
+    auto context = new XSAPI_XBOX_LIVE_CONTEXT();
+    context->pImpl = new XSAPI_XBOX_LIVE_CONTEXT_IMPL(pUser, context);
     return context;
 }
 
 XSAPI_DLLEXPORT void XBL_CALLING_CONV
 XboxLiveContextDelete(
-    XboxLiveContext *context
+    XSAPI_XBOX_LIVE_CONTEXT *context
     )
 {
     delete context->pImpl;

--- a/CppSource/Source/Services/Misc/title_callable_ui.cpp
+++ b/CppSource/Source/Services/Misc/title_callable_ui.cpp
@@ -16,7 +16,7 @@ HC_RESULT TCUIShowProfileCardUIExecute(
     auto result = title_callable_ui::show_profile_card_ui(utils::to_utf16string(args->targetXboxUserId)).get();
 
     args->resultErrorMsg = result.err_message();
-    args->result.errorCode = result.err().value();
+    args->result.errorCode = utils::xsapi_result_from_xbox_live_result_err(result.err());
     args->result.errorMessage = args->resultErrorMsg.c_str();
 
     return HCTaskSetCompleted(taskHandle);
@@ -26,7 +26,7 @@ HC_RESULT TCUIShowProfileCardUIExecute(
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 TCUIShowProfileCardUI(
     _In_ PCSTR targetXboxUserId,
-    _In_ TCUIShowProfileCardUICompletionRoutine completionRoutine,
+    _In_ XSAPI_SHOW_PROFILE_CARD_UI_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT
@@ -42,7 +42,7 @@ try
             taskGroupId,
             TCUIShowProfileCardUIExecute,
             static_cast<void*>(args),
-            xbl_execute_callback_fn<xbl_args_tcui_show_profile_card_ui, TCUIShowProfileCardUICompletionRoutine>,
+            xbl_execute_callback_fn<xbl_args_tcui_show_profile_card_ui, XSAPI_SHOW_PROFILE_CARD_UI_COMPLETION_ROUTINE>,
             static_cast<void*>(args),
             static_cast<void*>(completionRoutine),
             completionRoutineContext,
@@ -60,17 +60,17 @@ HC_RESULT TCUICheckGamingPrivilegeSilentlyExecute(
     auto result = title_callable_ui::check_gaming_privilege_silently((gaming_privilege)args->privilege);
 
     args->resultErrorMsg = result.err_message();
-    args->result.result.errorCode = result.err().value();
+    args->result.result.errorCode = utils::xsapi_result_from_xbox_live_result_err(result.err());
     args->result.result.errorMessage = args->resultErrorMsg.c_str();
     args->result.hasPrivilege = result.payload();
 
-    return HCTaskSetCompleted(taskHandle);    
+    return HCTaskSetCompleted(taskHandle);
 }
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 TCUICheckGamingPrivilegeSilently(
-    _In_ GAMING_PRIVILEGE privilege,
-    _In_ TCUICheckGamingPrivilegeCompletionRoutine completionRoutine,
+    _In_ XSAPI_GAMING_PRIVILEGE privilege,
+    _In_ XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT
@@ -86,7 +86,7 @@ try
             taskGroupId,
             TCUICheckGamingPrivilegeSilentlyExecute,
             static_cast<void*>(tcuiArgs),
-            xbl_execute_callback_fn<xbl_args_tcui_check_gaming_privilege, TCUICheckGamingPrivilegeCompletionRoutine>,
+            xbl_execute_callback_fn<xbl_args_tcui_check_gaming_privilege, XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE>,
             static_cast<void*>(tcuiArgs),
             static_cast<void*>(completionRoutine),
             completionRoutineContext,
@@ -109,7 +109,7 @@ HC_RESULT TCUICheckGamingPrivilegeWithUIExecute(
         ).get();
 
     args->resultErrorMsg = result.err_message();
-    args->result.result.errorCode = result.err().value();
+    args->result.result.errorCode = utils::xsapi_result_from_xbox_live_result_err(result.err());
     args->result.result.errorMessage = args->resultErrorMsg.c_str();
     args->result.hasPrivilege = result.payload();
 
@@ -118,9 +118,9 @@ HC_RESULT TCUICheckGamingPrivilegeWithUIExecute(
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 TCUICheckGamingPrivilegeWithUI(
-    _In_ GAMING_PRIVILEGE privilege,
+    _In_ XSAPI_GAMING_PRIVILEGE privilege,
     _In_ PCSTR friendlyMessage,
-    _In_ TCUICheckGamingPrivilegeCompletionRoutine completionRoutine,
+    _In_ XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE completionRoutine,
     _In_opt_ void* completionRoutineContext,
     _In_ uint64_t taskGroupId
     ) XSAPI_NOEXCEPT
@@ -137,7 +137,7 @@ try
             taskGroupId,
             TCUICheckGamingPrivilegeWithUIExecute,
             static_cast<void*>(tcuiArgs),
-            xbl_execute_callback_fn<xbl_args_tcui_check_gaming_privilege, TCUICheckGamingPrivilegeCompletionRoutine>,
+            xbl_execute_callback_fn<xbl_args_tcui_check_gaming_privilege, XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE>,
             static_cast<void*>(tcuiArgs),
             static_cast<void*>(completionRoutine),
             completionRoutineContext,

--- a/CppSource/Source/Shared/singleton.h
+++ b/CppSource/Source/Shared/singleton.h
@@ -5,8 +5,8 @@
 #include "threadpool.h"
 #include "xbox_live_app_config_impl.h"
 
-struct XboxLiveUser;
-struct XboxLiveAppConfig;
+struct XSAPI_XBOX_LIVE_USER;
+struct XSAPI_XBOX_LIVE_APP_CONFIG;
 
 struct xsapi_singleton
 {
@@ -17,10 +17,10 @@ struct xsapi_singleton
     std::unique_ptr<xsapi_thread_pool> m_threadPool;
 
     std::mutex m_usersLock;
-    std::map<std::string, XboxLiveUser*> m_signedInUsers;
+    std::map<std::string, XSAPI_XBOX_LIVE_USER*> m_signedInUsers;
 
-    std::shared_ptr<XboxLiveAppConfig> m_appConfigSingleton;
-    std::unique_ptr<XboxLiveAppConfigImpl> m_appConfigImplSingleton;
+    std::shared_ptr<XSAPI_XBOX_LIVE_APP_CONFIG> m_appConfigSingleton;
+    std::unique_ptr<XBOX_LIVE_APP_CONFIG_IMPL> m_appConfigImplSingleton;
 };
 
 xsapi_singleton* get_xsapi_singleton(_In_ bool createIfRequired = false);

--- a/CppSource/Source/Shared/utils.cpp
+++ b/CppSource/Source/Shared/utils.cpp
@@ -86,30 +86,68 @@ std::wstring utils::to_utf16string(const std::string& utf8)
 XSAPI_RESULT utils::std_bad_alloc_to_result(std::bad_alloc const& e, _In_z_ char const* file, uint32_t line)
 {
     HC_TRACE_ERROR(XSAPI_C_TRACE, "[%d] std::bad_alloc reached api boundary: %s\n    %s:%u",
-        XSAPI_E_OUTOFMEMORY, e.what(), file, line);
-    return XSAPI_E_OUTOFMEMORY;
+        XSAPI_RESULT_E_HC_OUTOFMEMORY, e.what(), file, line);
+    return XSAPI_RESULT_E_HC_OUTOFMEMORY;
 }
 
 XSAPI_RESULT utils::std_exception_to_result(std::exception const& e, _In_z_ char const* file, uint32_t line)
 {
     HC_TRACE_ERROR(XSAPI_C_TRACE, "[%d] std::exception reached api boundary: %s\n    %s:%u",
-        XSAPI_E_FAIL, e.what(), file, line);
+        XSAPI_RESULT_E_GENERIC_ERROR, e.what(), file, line);
 
     assert(false);
-    return XSAPI_E_FAIL;
+    return XSAPI_RESULT_E_GENERIC_ERROR;
 }
 
 XSAPI_RESULT utils::unknown_exception_to_result(_In_z_ char const* file, uint32_t line)
 {
     HC_TRACE_ERROR(XSAPI_C_TRACE, "[%d] unknown exception reached api boundary\n    %s:%u",
-        XSAPI_E_FAIL, file, line);
+        XSAPI_RESULT_E_GENERIC_ERROR, file, line);
 
     assert(false);
-    return XSAPI_E_FAIL;
+    return XSAPI_RESULT_E_GENERIC_ERROR;
 }
 
 XSAPI_RESULT utils::xsapi_result_from_hc_result(HC_RESULT hcr)
 {
-    // TODO make this is a bit more robust
+    if (hcr == HC_OK)
+    {
+        return XSAPI_RESULT_OK;
+    }
+    else if (hcr < XSAPI_RESULT_E_HC_MIN || hcr > XSAPI_RESULT_E_HC_MAX)
+    {
+        return XSAPI_RESULT_E_HC_FAIL;
+    }
     return static_cast<XSAPI_RESULT>(hcr);
+}
+
+XSAPI_RESULT utils::xsapi_result_from_xbox_live_result_err(std::error_code errc)
+{
+    switch (errc.default_error_condition().value())
+    {
+    case (int)xbox::services::xbox_live_error_condition::no_error:
+        return XSAPI_RESULT_OK;
+    case (int)xbox::services::xbox_live_error_condition::auth:
+        return XSAPI_RESULT_E_AUTH;
+    case (int)xbox::services::xbox_live_error_condition::generic_error: 
+        return XSAPI_RESULT_E_GENERIC_ERROR;
+    case (int)xbox::services::xbox_live_error_condition::generic_out_of_range: 
+        return XSAPI_RESULT_E_OUT_OF_RANGE;
+    case (int)xbox::services::xbox_live_error_condition::http: 
+        return XSAPI_RESULT_E_HTTP;
+    case (int)xbox::services::xbox_live_error_condition::http_404_not_found: 
+        return XSAPI_RESULT_E_HTTP_404_NOT_FOUND;
+    case (int)xbox::services::xbox_live_error_condition::http_412_precondition_failed: 
+        return XSAPI_RESULT_E_HTTP_412_PRECONDITION_FAILED;
+    case (int)xbox::services::xbox_live_error_condition::http_429_too_many_requests: 
+        return XSAPI_RESULT_E_HTTP_429_TOO_MANY_REQUESTS;
+    case (int)xbox::services::xbox_live_error_condition::http_service_timeout: 
+        return XSAPI_RESULT_E_HTTP_SERVICE_TIMEOUT;
+    case (int)xbox::services::xbox_live_error_condition::network: 
+        return XSAPI_RESULT_E_NETWORK;
+    case (int)xbox::services::xbox_live_error_condition::rta: 
+        return XSAPI_RESULT_E_RTA;
+    default: 
+        return XSAPI_RESULT_E_GENERIC_ERROR;
+    }
 }

--- a/CppSource/Source/Shared/utils.h
+++ b/CppSource/Source/Shared/utils.h
@@ -51,6 +51,7 @@ public:
         );
 
     static XSAPI_RESULT xsapi_result_from_hc_result(HC_RESULT hcr);
+    static XSAPI_RESULT xsapi_result_from_xbox_live_result_err(std::error_code errc);
 };
 
 template<typename T, typename T2>

--- a/CppSource/Source/Shared/xbox_live_app_config.cpp
+++ b/CppSource/Source/Shared/xbox_live_app_config.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "xsapi/xbox_live_app_config_c.h"
 
-XboxLiveAppConfigImpl::XboxLiveAppConfigImpl()
+XBOX_LIVE_APP_CONFIG_IMPL::XBOX_LIVE_APP_CONFIG_IMPL()
 {
     auto singleton = get_xsapi_singleton();
     std::lock_guard<std::mutex> lock(singleton->m_singletonLock);
@@ -23,13 +23,13 @@ XboxLiveAppConfigImpl::XboxLiveAppConfigImpl()
 
 XSAPI_DLLEXPORT XSAPI_RESULT XBL_CALLING_CONV
 GetXboxLiveAppConfigSingleton(
-    _Out_  XboxLiveAppConfig const** ppConfig
+    _Out_  CONST XSAPI_XBOX_LIVE_APP_CONFIG** ppConfig
     ) XSAPI_NOEXCEPT
 try
 {
     if (ppConfig == nullptr)
     {
-        return XSAPI_E_INVALIDARG;
+        return XSAPI_RESULT_E_HC_INVALIDARG;
     }
     
     auto singleton = get_xsapi_singleton();
@@ -37,11 +37,11 @@ try
 
     if (singleton->m_appConfigSingleton == nullptr)
     {
-        singleton->m_appConfigSingleton = std::make_shared<XboxLiveAppConfig>();
-        singleton->m_appConfigImplSingleton = std::make_unique<XboxLiveAppConfigImpl>();
+        singleton->m_appConfigSingleton = std::make_shared<XSAPI_XBOX_LIVE_APP_CONFIG>();
+        singleton->m_appConfigImplSingleton = std::make_unique<XBOX_LIVE_APP_CONFIG_IMPL>();
     }
     *ppConfig = singleton->m_appConfigSingleton.get();
    
-    return XSAPI_OK;
+    return XSAPI_RESULT_OK;
 }
 CATCH_RETURN()

--- a/CppSource/Source/System/user_impl.h
+++ b/CppSource/Source/System/user_impl.h
@@ -5,57 +5,20 @@
 
 #include "xsapi/system_c.h"
 
-struct XboxLiveUserImpl
+struct XSAPI_XBOX_LIVE_USER_IMPL
 {
-    XboxLiveUserImpl(
-        _In_ Windows::System::User^ creationContext,
-        _In_ XboxLiveUser *cUser
-        )
-        : m_cUser(cUser)
-    {
-        if (creationContext != nullptr)
-        {
-            m_cppUser = std::make_shared<xbox::services::system::xbox_live_user>(creationContext);
-        }
-        else
-        {
-            m_cppUser = std::make_shared<xbox::services::system::xbox_live_user>();
-        }
-    }
+public:
+    XSAPI_XBOX_LIVE_USER_IMPL(_In_ Windows::System::User^ creationContext, _In_ XSAPI_XBOX_LIVE_USER* pUser);
+    void Refresh();
+    std::shared_ptr<xbox::services::system::xbox_live_user> cppUser() const;
 
-    void Refresh()
-    {
-        if (m_cUser != nullptr)
-        {
-            m_xboxUserId = utils::to_utf8string(m_cppUser->xbox_user_id());
-            m_cUser->xboxUserId = m_xboxUserId.data();
-
-            m_gamertag = utils::to_utf8string(m_cppUser->gamertag());
-            m_cUser->gamertag = m_gamertag.data();
-
-            m_ageGroup = utils::to_utf8string(m_cppUser->age_group());
-            m_cUser->ageGroup = m_ageGroup.data();
-
-            m_privileges = utils::to_utf8string(m_cppUser->privileges());
-            m_cUser->privileges = m_privileges.data();
-
-            m_cUser->isSignedIn = m_cppUser->is_signed_in();
-
-#if WINAPI_FAMILY && WINAPI_FAMILY==WINAPI_FAMILY_APP
-            m_webAccountId = utils::to_utf8string(m_cppUser->web_account_id());
-            m_cUser->webAccountId = m_webAccountId.data();
-#endif
-            m_cUser->windowsSystemUser = m_cppUser->windows_system_user();
-        }
-    }
-
+private:
     std::string m_xboxUserId;
     std::string m_gamertag;
     std::string m_ageGroup;
     std::string m_privileges;
     std::string m_webAccountId;
 
-    XboxLiveUser* m_cUser;
+    XSAPI_XBOX_LIVE_USER* m_pUser;
     std::shared_ptr<xbox::services::system::xbox_live_user> m_cppUser;
-
 };

--- a/CppSource/Source/System/user_impl_c.cpp
+++ b/CppSource/Source/System/user_impl_c.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pch.h"
+#include "user_impl.h"
+
+XSAPI_XBOX_LIVE_USER_IMPL::XSAPI_XBOX_LIVE_USER_IMPL(
+    _In_ Windows::System::User^ creationContext,
+    _In_ XSAPI_XBOX_LIVE_USER* pUser
+    )
+    : m_pUser(pUser)
+{
+    if (creationContext != nullptr)
+    {
+        m_cppUser = std::make_shared<xbox::services::system::xbox_live_user>(creationContext);
+    }
+    else
+    {
+        m_cppUser = std::make_shared<xbox::services::system::xbox_live_user>();
+    }
+}
+
+void XSAPI_XBOX_LIVE_USER_IMPL::Refresh()
+{
+    if (m_pUser != nullptr)
+    {
+        m_xboxUserId = utils::to_utf8string(m_cppUser->xbox_user_id());
+        m_pUser->xboxUserId = m_xboxUserId.data();
+
+        m_gamertag = utils::to_utf8string(m_cppUser->gamertag());
+        m_pUser->gamertag = m_gamertag.data();
+
+        m_ageGroup = utils::to_utf8string(m_cppUser->age_group());
+        m_pUser->ageGroup = m_ageGroup.data();
+
+        m_privileges = utils::to_utf8string(m_cppUser->privileges());
+        m_pUser->privileges = m_privileges.data();
+
+        m_pUser->isSignedIn = m_cppUser->is_signed_in();
+
+#if WINAPI_FAMILY && WINAPI_FAMILY==WINAPI_FAMILY_APP
+        m_webAccountId = utils::to_utf8string(m_cppUser->web_account_id());
+        m_pUser->webAccountId = m_webAccountId.data();
+#endif
+        m_pUser->windowsSystemUser = m_cppUser->windows_system_user();
+    }
+}
+
+std::shared_ptr<xbox::services::system::xbox_live_user> XSAPI_XBOX_LIVE_USER_IMPL::cppUser() const
+{
+    return m_cppUser;
+}


### PR DESCRIPTION
Slightly extends error handling and makes naming conventions consistent throughout.