### PR TITLE
Fixing calling convention bug causing exception on x86 il2cpp configuration

### DIFF
--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Common/XboxLiveAppConfiguration.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Common/XboxLiveAppConfiguration.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Xbox.Services
             public IntPtr sandbox;
         };
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT GetXboxLiveAppConfigSingleton(
             out IntPtr ppConfig);
     }

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Leaderboard/LeaderboardQuery.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Leaderboard/LeaderboardQuery.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Xbox.Services.Leaderboard
         /// <summary>
         /// Create a new query
         /// </summary>
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr LeaderboardQueryCreate();
         public LeaderboardQuery()
         {

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Social/Manager/SocialManager.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Social/Manager/SocialManager.cs
@@ -214,28 +214,28 @@ namespace Microsoft.Xbox.Services.Social.Manager
         }
 
         // Marshaling
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerAddLocalUser(IntPtr user, SocialManagerExtraDetailLevel extraDetailLevel, out IntPtr errMessage);
         
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerRemoveLocalUser(IntPtr user, out IntPtr errMessage);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerCreateSocialUserGroupFromFilters(IntPtr user, PresenceFilter presenceDetailFilter, RelationshipFilter filter, out IntPtr returnGroup, out IntPtr errMessage);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerCreateSocialUserGroupFromList(IntPtr group, IntPtr users, UInt32 usersCount, out IntPtr returnGroup, out IntPtr errMessage);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerUpdateSocialUserGroup(IntPtr group, IntPtr users, UInt32 usersCount, out IntPtr errMessage);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerDestroySocialUserGroup(IntPtr group, out IntPtr errMessage);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr SocialManagerDoWork(out UInt32 numOfEvents);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT SocialManagerSetRichPresencePollingStatus(IntPtr user, bool shouldEnablePolling, out IntPtr errMessage);
 
 

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Social/Manager/SocialManagerPresenceRecord.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Social/Manager/SocialManagerPresenceRecord.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xbox.Services.Social.Manager
 
     public partial class SocialManagerPresenceRecord : ISocialManagerPresenceRecord, IEquatable<SocialManagerPresenceRecord>
     {
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern bool SocialManagerPresenceRecordIsUserPlayingTitle(IntPtr socialManagerPresenceRecord, uint titleId);
 
         public bool IsUserPlayingTitle(uint titleId)

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Social/Manager/XboxSocialUserGroup.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Social/Manager/XboxSocialUserGroup.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Xbox.Services.Social.Manager
         }
 
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr XboxSocialUserGroupGetUsersFromXboxUserIds(IntPtr group, IntPtr xboxUserIds, UInt32 xboxUserIdsCount, IntPtr usersSize);
         public IList<XboxSocialUser> GetUsersFromXboxUserIds(IList<string> xboxUserIds)
         {

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Statistics/Manager/StatisticManager.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/Statistics/Manager/StatisticManager.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             throw new XboxException("User doesn't exist. Did you call AddLocalUser?");
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerAddLocalUser(IntPtr user, out IntPtr errMessage);
         public void AddLocalUser(XboxLiveUser user)
         {
@@ -44,7 +44,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             m_localUsers[user.Impl.XboxLiveUserPtr] = user;
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerRemoveLocalUser(IntPtr user, out IntPtr errMessage);
         public void RemoveLocalUser(XboxLiveUser user)
         {
@@ -66,7 +66,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerRequestFlushToService(IntPtr user, bool isHighPriority, out IntPtr errMessage);
         public void RequestFlushToService(XboxLiveUser user, bool isHighPriority = false)
         {
@@ -82,7 +82,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr StatsManagerDoWork(out Int32 numOfEvents);
         public IList<StatisticEvent> DoWork()
         {
@@ -113,7 +113,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             return events.AsReadOnly();
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerSetStatisticNumberData(IntPtr user, string statName, double value, out IntPtr errMessage);
         public void SetStatisticNumberData(XboxLiveUser user, string statName, double value)
         {
@@ -129,7 +129,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerSetStatisticIntegerData(IntPtr user, string statName, long value, out IntPtr errMessage);
         public void SetStatisticIntegerData(XboxLiveUser user, string statName, long value)
         {
@@ -143,7 +143,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerSetStatisticStringData(IntPtr user, string statName, string value, out IntPtr errMessage);
         public void SetStatisticStringData(XboxLiveUser user, string statName, string value)
         {
@@ -157,7 +157,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerDeleteStat(IntPtr user, string statName, out IntPtr errMessage);
         public void DeleteStatistic(XboxLiveUser user, string statName)
         {
@@ -173,7 +173,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerGetLeaderboard(IntPtr user, string statName, IntPtr query, out IntPtr errMessage);
         public void GetLeaderboard(XboxLiveUser user, string statName, LeaderboardQuery query)
         {
@@ -189,7 +189,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerGetSocialLeaderboard(IntPtr user, string statName, string socialGroup, IntPtr query, out IntPtr errMessage);
         public void GetSocialLeaderboard(XboxLiveUser user, string statName, string socialGroup, LeaderboardQuery query)
         {
@@ -205,7 +205,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             }
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerGetStat(IntPtr user, IntPtr statName, out IntPtr statValue, out IntPtr errMessage);
         public StatisticValue GetStatistic(XboxLiveUser user, string statName)
         {
@@ -231,7 +231,7 @@ namespace Microsoft.Xbox.Services.Statistics.Manager
             return statValue;
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT StatsManagerGetStatNames(IntPtr user, out IntPtr statNameList, out UInt32 statNameListCount, out IntPtr errMessage);
         public IList<string> GetStatisticNames(XboxLiveUser user)
         {

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/System/TitleCallableUI.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/System/TitleCallableUI.cs
@@ -146,21 +146,21 @@ namespace Microsoft.Xbox.Services.System
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE(XSAPI_RESULT_INFO result, bool hasPrivilege, IntPtr completionRoutineContext);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TCUIShowProfileCardUI(
             IntPtr targetXboxUserId, 
             XSAPI_SHOW_PROFILE_CARD_UI_COMPLETION_ROUTINE completionRoutine, 
             IntPtr completionRoutineContext, 
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TCUICheckGamingPrivilegeSilently(
             GamingPrivilege privilege,
             XSAPI_CHECK_GAMING_PRIVILEGE_COMPLETION_ROUTINE completionRoutine, 
             IntPtr completionRoutineContext, 
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TCUICheckGamingPrivilegeWithUI(
             GamingPrivilege privilege, 
             IntPtr friendlyMessage,

--- a/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/System/UserImpl.cs
+++ b/CSharpSource/Source/Microsoft.Xbox.Services.UWP.CSharp/System/UserImpl.cs
@@ -269,15 +269,15 @@ namespace Microsoft.Xbox.Services.System
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void XSAPI_SIGN_OUT_COMPLETED_HANDLER(IntPtr xboxLiveUserPtr);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT XboxLiveUserCreateFromSystemUser(
             IntPtr systemUser, 
             out IntPtr xboxLiveUserPtr);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void XboxLiveUserDelete(IntPtr xboxLiveUserPtr);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT XboxLiveUserSignInWithCoreDispatcher(
             IntPtr xboxLiveUserPtr, 
             IntPtr coreDispatcher, 
@@ -285,14 +285,14 @@ namespace Microsoft.Xbox.Services.System
             IntPtr completionRoutineContext, 
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT XboxLiveUserSignInSilently(
             IntPtr xboxLiveUserPtr, 
             XSAPI_SIGN_IN_COMPLETION_ROUTINE completionRoutine, 
             IntPtr completionRoutineContext, 
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT XboxLiveUserGetTokenAndSignature(
             IntPtr xboxLiveUserPtr, 
             IntPtr httpMethod,
@@ -303,10 +303,10 @@ namespace Microsoft.Xbox.Services.System
             IntPtr completionRoutineContext, 
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern Int32 AddSignOutCompletedHandler(XSAPI_SIGN_OUT_COMPLETED_HANDLER handler);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void RemoveSignOutCompletedHandler(Int32 functionContext);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/CSharpSource/Source/api/Common/XboxLive.cs
+++ b/CSharpSource/Source/api/Common/XboxLive.cs
@@ -137,10 +137,10 @@ namespace Microsoft.Xbox.Services
             }
         }
         
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT XsapiGlobalInitialize();
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void XsapiGlobalCleanup();
     }
 }

--- a/CSharpSource/Source/api/Common/XboxLiveServices.cs
+++ b/CSharpSource/Source/api/Common/XboxLiveServices.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Xbox.Services
         internal IntPtr XboxLiveContextPtr { get; private set; }
 
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern XSAPI_RESULT XboxLiveContextCreate(IntPtr xboxLiveUser, out IntPtr xboxLiveContext);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void XboxLiveContextDelete(IntPtr xboxLiveContext);
     }
 }

--- a/CSharpSource/Source/api/Leaderboard/LeaderboardQueryImpl.cs
+++ b/CSharpSource/Source/api/Leaderboard/LeaderboardQueryImpl.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Xbox.Services.Leaderboard
             m_maxItems = maxItems;
             LeaderboardQuerySetMaxItems(m_leaderboardQueryPtr, m_maxItems);
         }
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void LeaderboardQuerySetMaxItems(IntPtr leaderboardQuery, UInt32 maxItems);
 
         // Order
@@ -36,7 +36,7 @@ namespace Microsoft.Xbox.Services.Leaderboard
             m_order = order;
             LeaderboardQuerySetOrder(m_leaderboardQueryPtr, m_order);
         }
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void LeaderboardQuerySetOrder(IntPtr leaderboardQuery, SortOrder order);
 
         // SkipResultToMe
@@ -50,7 +50,7 @@ namespace Microsoft.Xbox.Services.Leaderboard
             m_skipResultToMe = skipResultToMe;
             LeaderboardQuerySetSkipResultToMe(m_leaderboardQueryPtr, m_skipResultToMe);
         }
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void LeaderboardQuerySetSkipResultToMe(IntPtr leaderboardQuery, bool skipResultToMe);
 
         // SkipResultToRank
@@ -64,7 +64,7 @@ namespace Microsoft.Xbox.Services.Leaderboard
             m_skipResultToRank = skipResultToRank;
             LeaderboardQuerySetSkipResultToRank(m_leaderboardQueryPtr, skipResultToRank);
         }
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void LeaderboardQuerySetSkipResultToRank(IntPtr leaderboardQuery, UInt32 setSkipResultToRank);
         
         public LeaderboardQueryImpl(IntPtr ptr, LeaderboardQuery query)

--- a/CSharpSource/Source/api/Leaderboard/LeaderboardResultImpl.cs
+++ b/CSharpSource/Source/api/Leaderboard/LeaderboardResultImpl.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Xbox.Services.Leaderboard
     {
         IntPtr m_leaderboardResultPtr;
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern bool LeaderboardResultHasNext(IntPtr leaderboard);
         public bool GetHasNext()
         {
             return LeaderboardResultHasNext(m_leaderboardResultPtr);
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT LeaderboardResultGetNextQuery(IntPtr leaderboard, IntPtr nextQuery, IntPtr errMessage);
         public LeaderboardQuery GetNextQueryImpl()
         {

--- a/CSharpSource/Source/api/Privacy/PrivacyService.cs
+++ b/CSharpSource/Source/api/Privacy/PrivacyService.cs
@@ -184,14 +184,14 @@ namespace Microsoft.Xbox.Services.Privacy
             UInt32 xboxUserIdsCount,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT PrivacyGetAvoidList(
             IntPtr xboxLiveContext, 
             XSAPI_PRIVACY_GET_USER_LIST_COMPLETION_ROUTINE completionRoutine,
             IntPtr completionRoutineContext,
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT PrivacyGetMuteList(
             IntPtr xboxLiveContext, 
             XSAPI_PRIVACY_GET_USER_LIST_COMPLETION_ROUTINE completionRoutine,
@@ -204,7 +204,7 @@ namespace Microsoft.Xbox.Services.Privacy
             XSAPI_PRIVACY_PERMISSION_CHECK_RESULT payload,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT PrivacyCheckPermissionWithTargetUser(
             IntPtr xboxLiveContext,
             IntPtr permissionId,
@@ -220,7 +220,7 @@ namespace Microsoft.Xbox.Services.Privacy
             UInt32 privacyCheckResultsCount,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT PrivacyCheckMultiplePermissionsWithMultipleTargetUsers(
             IntPtr xboxLiveContext,
             IntPtr permissionIds,

--- a/CSharpSource/Source/api/TitleStorage/TitleStorageBlobMetadata.cs
+++ b/CSharpSource/Source/api/TitleStorage/TitleStorageBlobMetadata.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             this.ClientTimeStamp = MarshalingHelpers.FromUnixTimeSeconds(CStruct.clientTimestamp);
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageCreateBlobMetadata(
             IntPtr serviceConfigurationId,
             TitleStorageType storageType,
@@ -202,7 +202,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             IntPtr pClientTimestamp,
             out IntPtr ppMetadata);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageReleaseBlobMetadata(
             IntPtr pMetadata);
     }

--- a/CSharpSource/Source/api/TitleStorage/TitleStorageBlobMetadataResult.cs
+++ b/CSharpSource/Source/api/TitleStorage/TitleStorageBlobMetadataResult.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             this.metadataResultStruct = cObject;
         }
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageBlobMetadataResultGetNext(
             XSAPI_TITLE_STORAGE_BLOB_METADATA_RESULT metadataResult,
             UInt32 maxItems,

--- a/CSharpSource/Source/api/TitleStorage/TitleStorageService.cs
+++ b/CSharpSource/Source/api/TitleStorage/TitleStorageService.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             XSAPI_TITLE_STORAGE_QUOTA quota, 
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageGetQuota(
             IntPtr xboxLiveContext, 
             IntPtr serviceConfigurationId,
@@ -316,7 +316,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             XSAPI_TITLE_STORAGE_BLOB_METADATA_RESULT payload,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageGetBlobMetadata(
             IntPtr xboxLiveContext,
             IntPtr serviceConfigurationId,
@@ -329,7 +329,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             IntPtr completionRoutineContext,
             Int64 taskGroupId);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageCreateBlobMetadata(
             IntPtr serviceConfigurationId,
             TitleStorageType storageType,
@@ -340,7 +340,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             IntPtr etag,
             IntPtr ppBlobMetadata);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageReleaseBlobMetadata(
             IntPtr serviceConfigurationId);
 
@@ -349,7 +349,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             XSAPI_RESULT_INFO result,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageDeleteBlob(
             IntPtr xboxLiveContext,
             IntPtr blobMetadataPointer,
@@ -364,7 +364,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             XSAPI_TITLE_STORAGE_BLOB_RESULT blobResult,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageDownloadBlob(
             IntPtr xboxLiveContext,
             IntPtr blobMetadataPointer,
@@ -383,7 +383,7 @@ namespace Microsoft.Xbox.Services.TitleStorage
             IntPtr pBlobMetadata,
             IntPtr context);
 
-        [DllImport(XboxLive.FlatCDllName)]
+        [DllImport(XboxLive.FlatCDllName, CallingConvention = CallingConvention.Cdecl)]
         private static extern XSAPI_RESULT TitleStorageUploadBlob(
             IntPtr xboxLiveContext,
             IntPtr blobMetadataPointer,


### PR DESCRIPTION
The pinvoke layer needed to specify the correct calling convention.  This resolves bug#200