### PR TITLE
Added null checks for LoadDataHelper return values

### DIFF
--- a/Assets/Xbox Live/GameSave/Scripts/GameSaveHelper.cs
+++ b/Assets/Xbox Live/GameSave/Scripts/GameSaveHelper.cs
@@ -108,9 +108,12 @@ namespace Microsoft.Xbox.Services.ConnectedStorage
                 if (this.gameSaveProvider != null)
                 {
                     var loadBuffers = this.LoadDataHelper(containerName, blobsToRead);
-                    foreach (var loadedBuffer in loadBuffers)
+                    if (loadBuffers != null)
                     {
-                        returnDictionary.Add(loadedBuffer.Key, loadedBuffer.Value.ToArray());
+                        foreach (var loadedBuffer in loadBuffers)
+                        {
+                            returnDictionary.Add(loadedBuffer.Key, loadedBuffer.Value.ToArray());
+                        }
                     }
                 }
                 else
@@ -146,12 +149,15 @@ namespace Microsoft.Xbox.Services.ConnectedStorage
                 if (this.gameSaveProvider != null)
                 {
                     var loadBuffers = this.LoadDataHelper(containerName, blobsToRead);
-                    foreach (var loadedBuffer in loadBuffers)
+                    if (loadBuffers != null)
                     {
-                        var loadedBufferValue = loadedBuffer.Value;
-                        var reader = DataReader.FromBuffer(loadedBufferValue);
-                        var loadedData = reader.ReadString(loadedBufferValue.Length);
-                        returnDictionary.Add(loadedBuffer.Key, loadedData);
+                        foreach (var loadedBuffer in loadBuffers)
+                        {
+                            var loadedBufferValue = loadedBuffer.Value;
+                            var reader = DataReader.FromBuffer(loadedBufferValue);
+                            var loadedData = reader.ReadString(loadedBufferValue.Length);
+                            returnDictionary.Add(loadedBuffer.Key, loadedData);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
Fix for the reported issue https://github.com/microsoft/xbox-live-unity-plugin/issues/281

Fixed by adding null checks on the return values of LoadDataHelper to not access the returned buffers in case they're null. This results the blob keys to not exist in the produced dictionary, so that client code can easily determine that a blob couldn't be loaded.