### PR TITLE
XboxLivePostProcessing - Remove dependency on Visual Studio Tools for Unity in XboxLivePostProcessing

### DIFF
--- a/Assets/Xbox Live/Editor/XboxLivePostProcessing.cs
+++ b/Assets/Xbox Live/Editor/XboxLivePostProcessing.cs
@@ -3,7 +3,6 @@
 // 
 namespace Assets.Xbox_Live.Editor
 {
-    using System;
     using System.IO;
     using System.Xml;
     using System.Xml.Linq;
@@ -11,52 +10,18 @@ namespace Assets.Xbox_Live.Editor
 
     using Microsoft.Xbox.Services;
 
-    using SyntaxTree.VisualStudio.Unity.Bridge;
-
     using UnityEditor;
     using UnityEditor.Callbacks;
 
     using UnityEngine;
 
     /// <summary>
-    /// Handles post processing the generated Visaul Studio projects in order to deal with DevCenter
+    /// Handles post processing the generated Visual Studio projects in order to deal with DevCenter
     /// association and including Xbox Live configuration files.
     /// </summary>
     [InitializeOnLoad]
     public class XboxLivePostProcessing
     {
-        static XboxLivePostProcessing()
-        {
-            ProjectFilesGenerator.ProjectFileGeneration += AddXboxServicesConfig;
-        }
-
-        /// <summary>
-        /// Adds the XboxServices.config file to the generated project file.
-        /// </summary>
-        /// <param name="fileName">The name of the file being processed.</param>
-        /// <param name="fileContent">The content of the file being processed.</param>
-        /// <returns>The project file with an additional content element included.</returns>
-        /// <remarks>
-        /// This only modifies the Unity debug projects and will not have any
-        /// effect on projects built as part of the Unity UWP build process.
-        /// </remarks>
-        private static string AddXboxServicesConfig(string fileName, string fileContent)
-        {
-            if (!fileName.EndsWith(".Editor.csproj"))
-            {
-                const string configFileElement =
-                    "    <Content Include=\"" + XboxLiveAppConfiguration.FileName + "\">\r\n" +
-                    "       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>\r\n" +
-                    "    </Content>\r\n";
-
-                // Hacky way to do this for now.  Should make it a bit more stable.
-                int lastItemGroup = fileContent.LastIndexOf("  </ItemGroup>", StringComparison.OrdinalIgnoreCase);
-                fileContent = fileContent.Insert(lastItemGroup, configFileElement);
-            }
-
-            return fileContent;
-        }
-
         [PostProcessBuild(1)]
         public static void OnPostprocessBuild(BuildTarget target, string solutionFolder)
         {

--- a/Assets/Xbox Live/Editor/XboxLivePostProcessingUnityProject.cs
+++ b/Assets/Xbox Live/Editor/XboxLivePostProcessingUnityProject.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// 
+namespace Assets.Xbox_Live.Editor
+{
+    using System;
+    using Microsoft.Xbox.Services;
+    using UnityEditor;
+
+    /// <summary>
+    /// Handles post processing the generated Visual Studio projects in order to deal with DevCenter
+    /// association and including Xbox Live configuration files.
+    /// </summary>
+    public class XboxLivePostProcessingUnityProject : AssetPostprocessor
+    {
+        private static string OnGeneratedCSProject(string path, string content)
+        {
+            return AddXboxServicesConfig(path, content);
+        }
+
+        /// <summary>
+        /// Adds the XboxServices.config file to the generated project file.
+        /// </summary>
+        /// <param name="fileName">The name of the file being processed.</param>
+        /// <param name="fileContent">The content of the file being processed.</param>
+        /// <returns>The project file with an additional content element included.</returns>
+        /// <remarks>
+        /// This only modifies the Unity debug projects and will not have any
+        /// effect on projects built as part of the Unity UWP build process.
+        /// </remarks>
+        private static string AddXboxServicesConfig(string fileName, string fileContent)
+        {
+            if (!fileName.EndsWith(".Editor.csproj"))
+            {
+                const string configFileElement =
+                    "    <Content Include=\"" + XboxLiveAppConfiguration.FileName + "\">\r\n" +
+                    "       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>\r\n" +
+                    "    </Content>\r\n";
+
+                // Hacky way to do this for now.  Should make it a bit more stable.
+                int lastItemGroup = fileContent.LastIndexOf("  </ItemGroup>", StringComparison.OrdinalIgnoreCase);
+                fileContent = fileContent.Insert(lastItemGroup, configFileElement);
+            }
+
+            return fileContent;
+        }
+    }
+}

--- a/Assets/Xbox Live/Editor/XboxLivePostProcessingUnityProject.cs.meta
+++ b/Assets/Xbox Live/Editor/XboxLivePostProcessingUnityProject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fe701e19650d9541b767bce400e693e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This post-processing step used a functionality of Visual Studio Tools for Unity for which there is an equivalent in Unity (at least in 2019.4.3f1).
By removing this dependency, it removes the obligation of having Visual Studio Tools for Unity installed on the machine building the project using Xbox Live plugin.
I moved the replaced functionality from XboxLivePostProcessing.cs to XboxLivePostProcessingUnityProject.cs.